### PR TITLE
🟠 Normal: Add selectable accessibility traits [Tiny]

### DIFF
--- a/Sources/Components/ARCListItemSelectable.swift
+++ b/Sources/Components/ARCListItemSelectable.swift
@@ -48,6 +48,7 @@ public struct ARCListItemSelectable: View {
                     .foregroundColor(Color.arcLightGray)
                 , alignment: .bottom
             )
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
         }
     }
 }

--- a/Sources/Components/ARCSelectable.swift
+++ b/Sources/Components/ARCSelectable.swift
@@ -58,6 +58,7 @@ public struct ARCSelectable: View {
                     .strokeBorder(
                         isSelected ? Color.arcRed : Color.arcBorderGray, lineWidth: .arcBorder)
             )
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
         }
     }
 }


### PR DESCRIPTION
Add `.isSelected` accessibility trait where applicable