### PR TITLE
ARCListItem Styling props

### DIFF
--- a/Sources/Components/ARCListItem.swift
+++ b/Sources/Components/ARCListItem.swift
@@ -21,6 +21,7 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
     public var background: Color?
     public var titleForeground: Color?
     public var subtitleForeground: Color?
+    public var borderColor: Color?
     public var verticalPadding: CGFloat?
 
     @ViewBuilder public var leading: () -> Leading
@@ -36,6 +37,7 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
         background: Color? = Color.arcWhite,
         titleForeground: Color? = Color.arcBlack,
         subtitleForeground: Color? = Color.arcDarkGray,
+        borderColor: Color? = Color.arcLightGray,
         verticalPadding: CGFloat? = nil
     ) {
         self.title = title
@@ -47,6 +49,7 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
         self.background = background
         self.titleForeground = titleForeground
         self.subtitleForeground = subtitleForeground
+        self.borderColor = borderColor
         self.verticalPadding = verticalPadding
     }
 
@@ -82,7 +85,7 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
         .overlay(
             Rectangle()
                 .frame(height: .arcBorder)
-                .foregroundColor(Color.arcLightGray)
+                .foregroundColor(borderColor)
             , alignment: .bottom
         )
     }

--- a/Sources/Components/ARCListItem.swift
+++ b/Sources/Components/ARCListItem.swift
@@ -38,7 +38,7 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
         titleForeground: Color? = Color.arcBlack,
         subtitleForeground: Color? = Color.arcDarkGray,
         borderColor: Color? = Color.arcLightGray,
-        verticalPadding: CGFloat? = nil
+        verticalPadding: CGFloat? = .ArcListItem.verticalPadding
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -74,7 +74,7 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .multilineTextAlignment(.leading)
-            .padding(.vertical, verticalPadding ?? .ArcListItem.verticalPadding)
+            .padding(.vertical, verticalPadding)
             .padding(subtitle == nil ? EdgeInsets.arcListItemContainer : EdgeInsets.arcListItemContainerSubtitle)
             trailing()
             .padding(.trailing, .ArcListItem.trailingPadding)

--- a/Sources/Components/ARCListItem.swift
+++ b/Sources/Components/ARCListItem.swift
@@ -53,7 +53,6 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
         self.verticalPadding = verticalPadding
     }
 
-
     public var body: some View {
         Button(action: onTap) {
             HStack(spacing: 0) {

--- a/Sources/Components/ARCListItem.swift
+++ b/Sources/Components/ARCListItem.swift
@@ -12,10 +12,16 @@ import CubeFoundationSwiftUI
 /// List Item Component
 public struct ARCListItem<Leading: View, Trailing: View>: View {
 
+    /// Functional
     public var title: String
     public var subtitle: String?
     public var labelTitle: String?
     public var onTap: () -> Void
+    /// Styling
+    public var background: Color?
+    public var titleForeground: Color?
+    public var subtitleForeground: Color?
+    public var verticalPadding: CGFloat?
 
     @ViewBuilder public var leading: () -> Leading
     @ViewBuilder public var trailing: () -> Trailing
@@ -26,7 +32,11 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
         labelTitle: String? = nil,
         @ViewBuilder leading: @escaping () -> Leading,
         @ViewBuilder trailing: @escaping () -> Trailing,
-        onTap: @escaping () -> Void
+        onTap: @escaping () -> Void,
+        background: Color? = Color.arcWhite,
+        titleForeground: Color? = Color.arcBlack,
+        subtitleForeground: Color? = Color.arcDarkGray,
+        verticalPadding: CGFloat? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -34,7 +44,12 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
         self.leading = leading
         self.trailing = trailing
         self.onTap = onTap
+        self.background = background
+        self.titleForeground = titleForeground
+        self.subtitleForeground = subtitleForeground
+        self.verticalPadding = verticalPadding
     }
+
 
     public var body: some View {
         Button(action: onTap) {
@@ -43,11 +58,11 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
                 VStack(alignment: .leading, spacing: .ArcListItem.spacing) {
                     Text(title)
                         .style(.arcH4)
-                        .foregroundColor(.arcBlack)
+                        .foregroundColor(titleForeground)
                     if let subtitle {
                         Text(subtitle)
                             .style(.arcBody2)
-                            .foregroundColor(.arcDarkGray)
+                            .foregroundColor(subtitleForeground)
                     }
                 }
                 if let labelTitle {
@@ -57,12 +72,13 @@ public struct ARCListItem<Leading: View, Trailing: View>: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .multilineTextAlignment(.leading)
+            .padding(.vertical, verticalPadding ?? .ArcListItem.verticalPadding)
             .padding(subtitle == nil ? EdgeInsets.arcListItemContainer : EdgeInsets.arcListItemContainerSubtitle)
             trailing()
-                .padding(.trailing, .ArcListItem.trailingPadding)
+            .padding(.trailing, .ArcListItem.trailingPadding)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.arcWhite)
+        .background(background)
         .overlay(
             Rectangle()
                 .frame(height: .arcBorder)
@@ -85,6 +101,34 @@ struct ARCListItem_Previews: PreviewProvider {
                             .padding(.leading, .ArcListItem.chevronPadding)
                     },
                     onTap: {}
+                )
+                ARCListItem(
+                    title: "Map Overlay",
+                    leading: { EmptyView() },
+                    trailing: {
+                        Image.arcRoundedRightChevron
+                            .padding(.leading, .ArcListItem.chevronPadding)
+                    },
+                    onTap: {},
+                    background: Color.arcCharcoal,
+                    titleForeground: Color.arcWhite
+                )
+                ARCListItem(
+                    title: "Map Overlay",
+                    leading: { EmptyView() },
+                    trailing: {
+                        Image.arcRoundedRightChevron
+                            .padding(.leading, .ArcListItem.chevronPadding)
+                    },
+                    onTap: {},
+                    background: Color.arcBlack,
+                    titleForeground: Color.arcWhite,
+                    verticalPadding: 20
+                )
+                .cornerRadius(.arcCornerRadius)
+                .overlay(
+                    RoundedRectangle(cornerRadius: .arcCornerRadius)
+                        .strokeBorder(Color.arcDarkGray, lineWidth: .arcBorder)
                 )
                 ARCListItem(
                     title: "Map Overlay",

--- a/Sources/Values/CGFloat+Values.swift
+++ b/Sources/Values/CGFloat+Values.swift
@@ -95,16 +95,16 @@ public extension EdgeInsets {
     )
 
     static let arcListItemContainer = EdgeInsets(
-        top: .ArcListItem.verticalPadding,
+        top: 0,
         leading: .ArcListItem.leadingPadding,
-        bottom: .ArcListItem.verticalPadding,
+        bottom: 0,
         trailing: .ArcListItem.trailingPadding
     )
 
     static let arcListItemContainerSubtitle = EdgeInsets(
-        top: .ArcListItem.verticalPaddingSubtitle,
+        top: 0,
         leading: .ArcListItem.leadingPadding,
-        bottom: .ArcListItem.verticalPaddingSubtitle,
+        bottom: 0,
         trailing: .ArcListItem.trailingPadding
     )
 

--- a/Sources/Values/CGFloat+Values.swift
+++ b/Sources/Values/CGFloat+Values.swift
@@ -30,8 +30,8 @@ public extension CGFloat {
         static let chevronPadding: CGFloat = 24
         static let leadingPadding: CGFloat = 25
         static let trailingPadding: CGFloat = 16
-        static let verticalPadding: CGFloat = 32
-        static let verticalPaddingSubtitle: CGFloat = 26
+        public static let verticalPadding: CGFloat = 32
+        public static let verticalPaddingSubtitle: CGFloat = 26
         static let labelLeadingPadding: CGFloat = 6
     }
 


### PR DESCRIPTION
Modified `ArcListItem` to include styling properties to be used on dark mode versions of the component.
![Screenshot 2023-06-19 at 13 09 08](https://github.com/3sidedcube/ArcUI/assets/33767184/617819c1-4593-42c2-8246-aec1deb3092b)
