### PR TITLE
🟠 Normal: Fix invalid widths [Small]

### DIFF
--- a/Sources/Components/ARCImageCard.swift
+++ b/Sources/Components/ARCImageCard.swift
@@ -37,7 +37,8 @@ public struct ARCImageCard: View {
                 image
                     .resizable()
                     .scaledToFill()
-                    .frame(width: .infinity, height: .ArcImageCard.imageHeight)
+                    .frame(height: .ArcImageCard.imageHeight)
+                    .frame(maxWidth: .infinity)
                     .clipped()
                 // Body
                 VStack(alignment: .leading, spacing: 8) {

--- a/Sources/Components/ARCTitleImageCard.swift
+++ b/Sources/Components/ARCTitleImageCard.swift
@@ -40,7 +40,8 @@ public struct ARCTitleImageCard<Trailing: View>: View {
             image
                 .resizable()
                 .scaledToFill()
-                .frame(maxWidth: .infinity, maxHeight: .ArcTitleImageCard.imageHeight)
+                .frame(height: .ArcTitleImageCard.imageHeight)
+                .frame(maxWidth: .infinity)
                 .cornerRadius(.arcCornerRadius)
                 .padding(.top, .arcVerticalPadding)
             trailing()


### PR DESCRIPTION
Replaced 
```swift
.frame(width: .infinity, height: 123)
```
with
```swift
.frame(height: 123)
.frame(maxWidth: .infinity)
```

![Screenshot 2023-06-23 at 15 30 56](https://github.com/3sidedcube/ArcUI/assets/57952587/3376c668-a017-4e13-aeb1-0a51eaea8c83)
