### PR TITLE
Fix touch area

### DIFF
--- a/Sources/Components/ARCImageCard.swift
+++ b/Sources/Components/ARCImageCard.swift
@@ -72,7 +72,6 @@ public struct ARCImageCard: View {
             .cornerRadius(.arcCornerRadius)
             .shadow(.arcContainer)
         }
-        .buttonStyle(PlainButtonStyle())
     }
 }
 

--- a/Sources/Components/ARCImageCard.swift
+++ b/Sources/Components/ARCImageCard.swift
@@ -62,6 +62,7 @@ public struct ARCImageCard: View {
                 HStack(spacing: 0) {
                     Text(footerTitle)
                         .style(.arcH4)
+                        .foregroundColor(.arcBlack)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Image.arcRoundedRightChevron
                 }


### PR DESCRIPTION
Touch area was to far above the component - resulted in occasionally causing user to tap wrong card 