### PR TITLE
Add custom color support

### DIFF
--- a/Sources/Components/ARCButton.swift
+++ b/Sources/Components/ARCButton.swift
@@ -13,7 +13,7 @@ import CubeFoundationSwiftUI
 public struct ARCButton: View {
 
     /// Fixed set of button styles
-    public enum Style {
+    public enum Style: Equatable {
 
         /// Filled red
         case primary
@@ -26,6 +26,9 @@ public struct ARCButton: View {
 
         /// Disabled state
         case disabled
+
+        /// Custom state
+        case custom(backgroundColor: Color, borderColor: Color, textColor: Color)
     }
 
     @Environment(\.verticalSizeClass) var verticalSizeClass
@@ -100,6 +103,7 @@ private extension ARCButton.Style {
         case .secondary: return .clear
         case .underline: return .clear
         case .disabled: return .arcDarkGray
+        case .custom(let backgroundColor, _, _) : return backgroundColor
         }
     }
 
@@ -109,6 +113,7 @@ private extension ARCButton.Style {
         case .secondary: return .arcBlue
         case .underline: return .clear
         case .disabled: return .clear
+        case .custom(_, let borderColor, _) : return borderColor
         }
     }
 
@@ -118,6 +123,7 @@ private extension ARCButton.Style {
         case .secondary: return .arcBlue
         case .underline: return .arcBlue
         case .disabled: return .arcWhite
+        case .custom(_, _, let textColor) : return textColor
         }
     }
 }
@@ -140,6 +146,7 @@ struct ARCButton_Previews: PreviewProvider {
             ARCButton(title: "SECONDARY DISABLED", style: .secondary, onTap: {})
                 .disabled(true)
             ARCButton(title: "Underline", style: .underline, onTap: {})
+            ARCButton(title: "CUSTOM", style: .custom(backgroundColor: .arcBlue, borderColor: .clear, textColor: .arcWhite), onTap: {})
         }
         .padding()
 //        .previewInterfaceOrientation(.landscapeLeft)

--- a/Sources/ViewModifiers/StickyButton.swift
+++ b/Sources/ViewModifiers/StickyButton.swift
@@ -17,6 +17,7 @@ public struct StickyButton: ViewModifier {
     public var style: ARCButton.Style
     public var isEnabled: Bool
     public var isLoading: Bool
+    public var icon: Image?
     public var onTap: () -> Void
 
     /// Public memberwise initializer
@@ -25,19 +26,21 @@ public struct StickyButton: ViewModifier {
         style: ARCButton.Style,
         isEnabled: Bool = true,
         isLoading: Bool = false,
+        icon: Image? = nil,
         onTap: @escaping () -> Void
     ) {
         self.title = title
         self.style = style
         self.isEnabled = isEnabled
         self.isLoading = isLoading
+        self.icon = icon
         self.onTap = onTap
     }
 
     public func body(content: Content) -> some View {
         content.modifier(
             StickyBottom {
-                ARCButton(title: title, style: style, onTap: onTap)
+                ARCButton(title: title, style: style, icon: icon, onTap: onTap)
                     .disabled(!isEnabled)
                     .loading(isLoading)
                     .frame(maxWidth: verticalSizeClass == .regular ? nil : .infinity)


### PR DESCRIPTION
## What?

- Added a new `custom` style to the ARCButton
- This enables us to reuse this component for custom designs

This is needed to fulfil the design for ARCEM-4266.

## Why?

https://3sidedcube.atlassian.net/browse/ARCEM-4266

## Screenshots / Screen Recordings

<img width="554" height="1004" alt="Screenshot 2025-09-11 at 14 52 19" src="https://github.com/user-attachments/assets/cea19758-8d9c-4c00-aa3b-669e8d21950a" />


