### PR TITLE
Add reusable arc page header component

### DIFF
--- a/Sources/Components/ARCPageHeaderView.swift
+++ b/Sources/Components/ARCPageHeaderView.swift
@@ -9,8 +9,6 @@
 import SwiftUI
 
 struct ARCPageHeaderView<Content: View>: View {
-    @Environment(\.verticalSizeClass) var verticalSizeClass
-
     let backgroundColor: Color
     let content: () -> Content
     

--- a/Sources/Components/ARCPageHeaderView.swift
+++ b/Sources/Components/ARCPageHeaderView.swift
@@ -1,0 +1,29 @@
+//
+//  ARCPageHeaderView.swift
+//  ArcUI
+//
+//  Created by Neil Japhtha on 23/09/2025.
+//  Copyright © 2025 3 SIDED CUBE APP PRODUCTIONS LTD. All rights reserved.
+//
+
+import SwiftUI
+
+struct ARCPageHeaderView<Content: View>: View {
+    @Environment(\.verticalSizeClass) var verticalSizeClass
+
+    let backgroundColor: Color
+    let content: () -> Content
+    
+    let horizontalPadding: CGFloat
+    let verticalPadding: CGFloat
+
+    var body: some View {
+        content()
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(
+                backgroundColor
+            )
+    }
+}


### PR DESCRIPTION
## What?

- Added the `ARCPageHeaderView`
- This is used in various places in the latest design system

It's a container view that sits at the top of a given screen, under the navigation bar. It has a background color that is configurable, and can expand given the content provided.

## Screenshots / Screen Recordings

| In First Aid | In Emergency |
|----|----|
| <img width="231" height="438" alt="Screenshot 2025-09-23 at 16 09 14" src="https://github.com/user-attachments/assets/3b00b774-3b61-4c86-8f8a-ba66eb75fc89" /> | <img width="459" height="731" alt="Screenshot 2025-09-23 at 16 10 51" src="https://github.com/user-attachments/assets/8c3bd617-5e48-4ce0-bb6d-a51f69e53cd8" /> |