### PR TITLE
Add layout and text options to ARCButton

### DIFF
--- a/Sources/Components/ARCButton.swift
+++ b/Sources/Components/ARCButton.swift
@@ -30,6 +30,99 @@ public struct ARCButton: View {
         /// Custom state
         case custom(backgroundColor: Color, borderColor: Color, textColor: Color)
     }
+    
+    ///
+    /// A small helper type that describes how an ARCButton should size itself in different
+    /// interface orientations (portrait vs. landscape).
+    ///
+    /// ButtonLayout separates the sizing rules into two `Layout` configurations—one for
+    /// portrait and one for landscape—so that a button can expand to fill the available
+    /// width in portrait while using a fixed width in landscape, or any other combination
+    /// you define.
+    ///
+    /// Although ARCButton currently applies sizing directly via `verticalSizeClass`,
+    /// ButtonLayout documents and encapsulates the intended sizing behavior and can be
+    /// used to centralize those decisions.
+    ///
+    /// Example
+    /// ```swift
+    /// // Portrait: fill available width
+    /// // Landscape: fixed width of 336pt
+    /// let layout = ButtonLayout.default
+    ///
+    /// // Custom example:
+    /// let custom = ButtonLayout(
+    ///     portrait: .init(width: nil, maxWidth: .infinity), // full-width in portrait
+    ///     landscape: .init(width: 280, maxWidth: nil)       // fixed 280pt in landscape
+    /// )
+    /// ```
+    public struct ButtonLayout {
+        /// A concrete sizing rule for a button.
+        ///
+        /// - width:
+        ///   A fixed width to apply to the button. Use `nil` to avoid constraining the width
+        ///   explicitly. When non-nil, the button will be sized to this exact width.
+        ///
+        /// - maxWidth:
+        ///   A maximum width to apply to the button. Use `.infinity` to make the button
+        ///   stretch to fill the available horizontal space (equivalent to `frame(maxWidth: .infinity)`).
+        ///   Use `nil` to leave the maximum width unconstrained.
+        ///
+        /// Notes
+        /// - You can set both `width` and `maxWidth` to `nil` to let the button size to its
+        ///   intrinsic content.
+        /// - Prefer setting only one of `width` or `maxWidth` to avoid conflicting constraints.
+        public struct Layout {
+            /// A fixed width for the button. `nil` means no explicit width constraint.
+            public let width: CGFloat?
+
+            /// A maximum width for the button. Use `.infinity` to expand to fill available space.
+            /// `nil` means no explicit max-width constraint.
+            public let maxWidth: CGFloat?
+
+            /// The default portrait layout: stretches to full width.
+            ///
+            /// Equivalent to applying `frame(maxWidth: .infinity)` in SwiftUI.
+            public static let defaultPortrait: Layout = .init(
+                width: nil,
+                maxWidth: .infinity
+            )
+            
+            /// The default landscape layout: uses a fixed width of 336 points.
+            ///
+            /// Equivalent to applying `frame(width: 336)` in SwiftUI.
+            public static let defaultLandscape: Layout = .init(
+                width: .ArcButton.landscapeWidth,
+                maxWidth: nil
+            )
+
+            /// Public memberwise initializer
+            public init(width: CGFloat?, maxWidth: CGFloat?) {
+                self.width = width
+                self.maxWidth = maxWidth
+            }
+        }
+        
+        /// The layout rules used when the interface is in portrait (regular vertical size class).
+        public let portrait: Layout
+
+        /// The layout rules used when the interface is in landscape (compact vertical size class).
+        public let landscape: Layout
+
+        /// A ready-made configuration that mirrors the current default ARCButton behavior:
+        /// - Portrait: full-width (maxWidth = .infinity)
+        /// - Landscape: fixed width of 336pt
+        public static let `default`: ButtonLayout  = .init(
+            portrait: .defaultPortrait,
+            landscape: .defaultLandscape
+        )
+
+        /// Public memberwise initializer
+        public init(portrait: Layout, landscape: Layout) {
+            self.portrait = portrait
+            self.landscape = landscape
+        }
+    }
 
     @Environment(\.verticalSizeClass) var verticalSizeClass
     @Environment(\.isLoading) public var isLoading: Bool
@@ -39,6 +132,9 @@ public struct ARCButton: View {
     public var style: Style
     public var onTap: () -> Void
     public var icon: Image?
+    public var minimumScaleFactor: CGFloat
+    public var lineLimit: Int?
+    public var layout: ButtonLayout
 
     /// Mapped `Style` based on states
     private var buttonStyle: Style {
@@ -49,12 +145,18 @@ public struct ARCButton: View {
         title: String,
         style: Style,
         icon: Image? = nil,
+        minimumScaleFactor: CGFloat = 1,
+        lineLimit: Int? = nil,
+        layout: ButtonLayout = .default,
         onTap: @escaping () -> Void
     ) {
         self.title = title
         self.style = style
         self.icon = icon
         self.onTap = onTap
+        self.minimumScaleFactor = minimumScaleFactor
+        self.lineLimit = lineLimit
+        self.layout = layout
     }
 
     public var body: some View {
@@ -80,8 +182,8 @@ public struct ARCButton: View {
                     ))
                     .opacity(isLoading ? 1 : 0)
             }
-            .frame(width: verticalSizeClass == .regular ? nil : .ArcButton.landscapeWidth)
-            .frame(maxWidth: verticalSizeClass == .regular ? .infinity : nil)
+            .frame(width: verticalSizeClass == .regular ? layout.portrait.width : layout.landscape.width)
+            .frame(maxWidth: verticalSizeClass == .regular ? layout.portrait.maxWidth : layout.landscape.maxWidth)
             .padding(.ArcButton.padding)
             .background(buttonStyle.backgroundColor)
             .cornerRadius(.arcCornerRadius)

--- a/Sources/ViewModifiers/StickyButton.swift
+++ b/Sources/ViewModifiers/StickyButton.swift
@@ -18,6 +18,10 @@ public struct StickyButton: ViewModifier {
     public var isEnabled: Bool
     public var isLoading: Bool
     public var icon: Image?
+    public var minimumScaleFactor: CGFloat
+    public var lineLimit: Int?
+    public var layout: ARCButton.ButtonLayout
+    public var padding: EdgeInsets
     public var onTap: () -> Void
 
     /// Public memberwise initializer
@@ -27,6 +31,10 @@ public struct StickyButton: ViewModifier {
         isEnabled: Bool = true,
         isLoading: Bool = false,
         icon: Image? = nil,
+        minimumScaleFactor: CGFloat = 1,
+        lineLimit: Int? = nil,
+        layout: ARCButton.ButtonLayout = .default,
+        padding: EdgeInsets = .arcStickyContainer,
         onTap: @escaping () -> Void
     ) {
         self.title = title
@@ -35,16 +43,28 @@ public struct StickyButton: ViewModifier {
         self.isLoading = isLoading
         self.icon = icon
         self.onTap = onTap
+        self.minimumScaleFactor = minimumScaleFactor
+        self.lineLimit = lineLimit
+        self.layout = layout
+        self.padding = padding
     }
 
     public func body(content: Content) -> some View {
         content.modifier(
             StickyBottom {
-                ARCButton(title: title, style: style, icon: icon, onTap: onTap)
-                    .disabled(!isEnabled)
-                    .loading(isLoading)
-                    .frame(maxWidth: verticalSizeClass == .regular ? nil : .infinity)
-                    .padding(EdgeInsets.arcStickyContainer)
+                ARCButton(
+                    title: title,
+                    style: style,
+                    icon: icon,
+                    minimumScaleFactor: minimumScaleFactor,
+                    lineLimit: lineLimit,
+                    layout: layout,
+                    onTap: onTap
+                )
+                .disabled(!isEnabled)
+                .loading(isLoading)
+                .frame(maxWidth: verticalSizeClass == .regular ? nil : .infinity)
+                .padding(padding)
             }
         )
     }


### PR DESCRIPTION
## What?

- Add `minimumScaleFactor` and `lineLimit` options to ARCButton.
- Add `ButtonLayout` option to ARCButton for customisation.
- Add `padding` option to StickyBottom to specify the padding of the sticky element.

## Why?

[iOS - Mark as Complete CTA Text is Truncated on Task Detail Screen](https://3sidedcube.atlassian.net/browse/ARCEM-4350)
