### PR TITLE
Restructure the constructor for more consistent code aesthetics

### DIFF
--- a/Sources/Components/ARCPageHeaderView.swift
+++ b/Sources/Components/ARCPageHeaderView.swift
@@ -9,8 +9,6 @@
 import SwiftUI
 
 struct ARCPageHeaderView<Content: View>: View {
-    @Environment(\.verticalSizeClass) var verticalSizeClass
-
     let backgroundColor: Color
     let content: () -> Content
     

--- a/Sources/Components/ARCPageHeaderView.swift
+++ b/Sources/Components/ARCPageHeaderView.swift
@@ -1,0 +1,29 @@
+//
+//  ARCPageHeaderView.swift
+//  ArcUI
+//
+//  Created by Neil Japhtha on 23/09/2025.
+//  Copyright © 2025 3 SIDED CUBE APP PRODUCTIONS LTD. All rights reserved.
+//
+
+import SwiftUI
+
+struct ARCPageHeaderView<Content: View>: View {
+    @Environment(\.verticalSizeClass) var verticalSizeClass
+
+    let backgroundColor: Color
+    let content: () -> Content
+    
+    let horizontalPadding: CGFloat
+    let verticalPadding: CGFloat
+
+    var body: some View {
+        content()
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(
+                backgroundColor
+            )
+    }
+}

--- a/Sources/Components/ARCPageHeaderView.swift
+++ b/Sources/Components/ARCPageHeaderView.swift
@@ -8,14 +8,26 @@
 
 import SwiftUI
 
-struct ARCPageHeaderView<Content: View>: View {
+public struct ARCPageHeaderView<Content: View>: View {
     let backgroundColor: Color
     let content: () -> Content
     
     let horizontalPadding: CGFloat
     let verticalPadding: CGFloat
+    
+    public init(
+        backgroundColor: Color,
+        content: @escaping () -> Content,
+        horizontalPadding: CGFloat,
+        verticalPadding: CGFloat
+    ) {
+        self.backgroundColor = backgroundColor
+        self.content = content
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
+    }
 
-    var body: some View {
+    public var body: some View {
         content()
             .frame(maxWidth: .infinity)
             .padding(.horizontal, horizontalPadding)

--- a/Sources/Components/ARCPageHeaderView.swift
+++ b/Sources/Components/ARCPageHeaderView.swift
@@ -10,21 +10,20 @@ import SwiftUI
 
 public struct ARCPageHeaderView<Content: View>: View {
     let backgroundColor: Color
-    let content: () -> Content
-    
     let horizontalPadding: CGFloat
     let verticalPadding: CGFloat
+    let content: () -> Content
 
     public init(
         backgroundColor: Color,
-        content: @escaping () -> Content,
         horizontalPadding: CGFloat,
-        verticalPadding: CGFloat
+        verticalPadding: CGFloat,
+        content: @escaping () -> Content
     ) {
         self.backgroundColor = backgroundColor
-        self.content = content
         self.horizontalPadding = horizontalPadding
         self.verticalPadding = verticalPadding
+        self.content = content
     }
 
     public var body: some View {


### PR DESCRIPTION
## What?

- Make sure the content view is the last in the constructor properties
- This aligns more with other constructors in the SwiftUI world, where input properties come before view builders
