### PR TITLE
Pass cornerRadius and icon size

### DIFF
--- a/Sources/Components/ARCButton.swift
+++ b/Sources/Components/ARCButton.swift
@@ -135,6 +135,8 @@ public struct ARCButton: View {
     public var minimumScaleFactor: CGFloat
     public var lineLimit: Int?
     public var layout: ButtonLayout
+    public let cornerRadius: CGFloat
+    public let iconSize: CGFloat?
 
     /// Mapped `Style` based on states
     private var buttonStyle: Style {
@@ -148,15 +150,19 @@ public struct ARCButton: View {
         minimumScaleFactor: CGFloat = 1,
         lineLimit: Int? = nil,
         layout: ButtonLayout = .default,
+        cornerRadius: CGFloat = .arcCornerRadius,
+        iconSize: CGFloat? = nil,
         onTap: @escaping () -> Void
     ) {
         self.title = title
         self.style = style
         self.icon = icon
-        self.onTap = onTap
         self.minimumScaleFactor = minimumScaleFactor
         self.lineLimit = lineLimit
         self.layout = layout
+        self.cornerRadius = cornerRadius
+        self.iconSize = iconSize
+        self.onTap = onTap
     }
 
     public var body: some View {
@@ -167,7 +173,7 @@ public struct ARCButton: View {
                         icon
                             .resizable()
                             .scaledToFit()
-                            .frame(size: .ArcButton.iconSize)
+                            .frame(size: iconSize ?? .ArcButton.iconSize)
                             .padding(.trailing, .ArcButton.iconPadding)
                     }
                     Text(title)
@@ -186,9 +192,9 @@ public struct ARCButton: View {
             .frame(maxWidth: verticalSizeClass == .regular ? layout.portrait.maxWidth : layout.landscape.maxWidth)
             .padding(.ArcButton.padding)
             .background(buttonStyle.backgroundColor)
-            .cornerRadius(.arcCornerRadius)
+            .cornerRadius(cornerRadius)
             .overlay(
-                RoundedRectangle(cornerRadius: .arcCornerRadius)
+                RoundedRectangle(cornerRadius: cornerRadius)
                     .strokeBorder(buttonStyle.borderColor, lineWidth: .arcBorder)
             )
         }

--- a/Sources/ViewModifiers/StickyButton.swift
+++ b/Sources/ViewModifiers/StickyButton.swift
@@ -22,6 +22,8 @@ public struct StickyButton: ViewModifier {
     public var lineLimit: Int?
     public var layout: ARCButton.ButtonLayout
     public var padding: EdgeInsets
+    public let cornerRadius: CGFloat
+    public let iconSize: CGFloat?
     public var onTap: () -> Void
 
     /// Public memberwise initializer
@@ -35,6 +37,8 @@ public struct StickyButton: ViewModifier {
         lineLimit: Int? = nil,
         layout: ARCButton.ButtonLayout = .default,
         padding: EdgeInsets = .arcStickyContainer,
+        cornerRadius: CGFloat = .arcCornerRadius,
+        iconSize: CGFloat? = nil,
         onTap: @escaping () -> Void
     ) {
         self.title = title
@@ -42,11 +46,13 @@ public struct StickyButton: ViewModifier {
         self.isEnabled = isEnabled
         self.isLoading = isLoading
         self.icon = icon
-        self.onTap = onTap
         self.minimumScaleFactor = minimumScaleFactor
         self.lineLimit = lineLimit
         self.layout = layout
         self.padding = padding
+        self.cornerRadius = cornerRadius
+        self.iconSize = iconSize
+        self.onTap = onTap
     }
 
     public func body(content: Content) -> some View {
@@ -59,6 +65,8 @@ public struct StickyButton: ViewModifier {
                     minimumScaleFactor: minimumScaleFactor,
                     lineLimit: lineLimit,
                     layout: layout,
+                    cornerRadius: cornerRadius,
+                    iconSize: iconSize,
                     onTap: onTap
                 )
                 .disabled(!isEnabled)


### PR DESCRIPTION
## What?

- Customise cornerRadius and icon size

## Why?

- Need to pass cornerRadius of 12 and iconSize of 24 in [design](https://www.figma.com/design/HX9YCoMfip3xT1gfn5HEIc/%E2%9B%91%EF%B8%8F-ARC-Emergency-Designs---V5.1?node-id=32019-43353&t=xSuFNcXOrnaPnWTy-4)

## Screenshots / Screen Recordings

| Figma design - Emergency |
|--------|
| <img width="417" height="115" alt="Screenshot 2025-10-08 at 16 31 54" src="https://github.com/user-attachments/assets/3dcda817-10fe-46c6-abda-e924c8cf7f0b" /> | 
